### PR TITLE
Updating pluralize to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "mocha": "^3.2.0",
     "number-to-text": "^0.3.2",
     "phantomjs2": "^2.2.0",
-    "pluralize": "^3.1.0",
+    "pluralize": "^4.0.0",
     "postcss-loader": "^1.3.1",
     "raw-loader": "^0.5.1",
     "react": "^15.4.2",


### PR DESCRIPTION

Please update [pluralize](https://npmjs.org/package/pluralize) to version 4.0.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```ce8fa7f```](https://github.com/blakeembrey/pluralize/commit/ce8fa7f7486d292195f4bd330e7376eeca0f3f1d) ```v4.0.0```
 * [```1a8bf86```](https://github.com/blakeembrey/pluralize/commit/1a8bf868a5f3df06b5edb736d5a44ac99a70274b) ```Skip `s` behind non-English words (#51)```


View the [change log](https://github.com/blakeembrey/pluralize/compare/9b71c461921658ab8b4d5a6d93b8660b9c4efb93...ce8fa7f7486d292195f4bd330e7376eeca0f3f1d).