### PR TITLE
Updating css-loader to 0.28.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "browser-request": "^0.3.3",
     "change-case": "^3.0.1",
     "clean-webpack-plugin": "^0.1.15",
-    "css-loader": "^0.26.1",
+    "css-loader": "^0.28.4",
     "es6-promise-promise": "^1.0.0",
     "eslint": "^3.16.1",
     "eslint-plugin-react": "^6.10.0",


### PR DESCRIPTION

Please update [css-loader](https://npmjs.org/package/css-loader) to version 0.28.4.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```ec4006c```](https://github.com/webpack-contrib/css-loader/commit/ec4006c69083f139adc5a8b599c6d85d59954c3e) ```chore(release): 0.28.4```
 * [```f6673c8```](https://github.com/webpack-contrib/css-loader/commit/f6673c8460336e63bec229ea005056791016560c) ```fix: preserve leading underscore in class names (#&hellip;```
 * [```1a6b17d```](https://github.com/webpack-contrib/css-loader/commit/1a6b17da03b2a99a0bdefcf1c35c7767a715968e) ```chore(release): 0.28.3```
 * [```b90f492```](https://github.com/webpack-contrib/css-loader/commit/b90f4925e45e9fde08842bfb4138f94e040fe7f9) ```fix: correct plugin order for CSS Modules (#534)```
 * [```72947b0```](https://github.com/webpack-contrib/css-loader/commit/72947b04ef9bc1f5eaf0816212c7b5cf7e555373) ```chore(release): 0.28.2```
 * [```c3d0d91```](https://github.com/webpack-contrib/css-loader/commit/c3d0d91a3074faca9d89c026602be50c685ab652) ```fix: source maps path on `windows` (#532)```
 * [```fe4cf7a```](https://github.com/webpack-contrib/css-loader/commit/fe4cf7aba6bf67d2403a8d44d0ea010e4c36ba90) ```docs(README): fix typo (#531)```
 * [```ae67b2a```](https://github.com/webpack-contrib/css-loader/commit/ae67b2a9eab5b4e27146ac73aff8854b227a081a) ```chore(release): 0.28.1```
 * [```868fc94```](https://github.com/webpack-contrib/css-loader/commit/868fc946eac43ce5b670a9ca9ae97ebe13d9f022) ```fix: don't handle empty @import and url() (#513)```
 * [```06d27a1```](https://github.com/webpack-contrib/css-loader/commit/06d27a15652ecc15a6ea1029a1e142ab2f9bcfe0) ```fix: allow to specify a full hostname as a root UR&hellip;```
 * [```b8f5c8f```](https://github.com/webpack-contrib/css-loader/commit/b8f5c8fc3fa146df01a9dca65c475c33cc679bd5) ```perf: generate source maps only when explicitly se&hellip;```
 * [```760eefa```](https://github.com/webpack-contrib/css-loader/commit/760eefa9a5b112f69fd2f5fe337a4d08b1a0a769) ```docs(README): add extract-loader example (#518)```
 * [```b90d8dd```](https://github.com/webpack-contrib/css-loader/commit/b90d8dde0add56703dda2252bd7352acbb3100a2) ```docs(README): fix warning note about import (#519)```
 * [```c197343```](https://github.com/webpack-contrib/css-loader/commit/c1973436f43a2e61462fe7b331a395e9afa16518) ```docs(README): add note about compose when imports &hellip;```
 * [```de4356b```](https://github.com/webpack-contrib/css-loader/commit/de4356b6c869553c843f48e032432b4f8dfacb71) ```fix: case insensitivity of @import (#514)```


See the full [change log](https://github.com/webpack/css-loader/compare/7cb4cb75c4c850282ec79647dbdbf45a06897ce6...ec4006c69083f139adc5a8b599c6d85d59954c3e) for everything that changed in this release.