### PR TITLE
Updating autoprefixer to 7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/walaura/pancakes-or-waffles/issues",
   "dependencies": {
     "add-asset-html-webpack-plugin": "^2.0.1",
-    "autoprefixer": "^6.7.5",
+    "autoprefixer": "^7.1.1",
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.1.1",
     "babel-loader": "^7.0.0",


### PR DESCRIPTION

Please update [autoprefixer](https://npmjs.org/package/autoprefixer) to version 7.1.1.

If this passes your tests you can merge it in.  If not please use this branch for changes.

