### PR TITLE
Updating extract-text-webpack-plugin to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "es6-promise-promise": "^1.0.0",
     "eslint": "^3.19.0",
     "eslint-plugin-react": "^7.0.1",
-    "extract-text-webpack-plugin": "^2.0.0-rc.3",
+    "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.11.2",
     "fs-extra": "^3.0.1",
     "gulp": "github:gulpjs/gulp#4.0",
@@ -43,7 +43,7 @@
     "style-loader": "^0.18.2",
     "twit": "^2.2.5",
     "url-loader": "^0.5.7",
-    "webpack": "^2.6.1",
+    "webpack": "^3.1.0",
     "webpack-merge": "^4.0.0",
     "webshot": "git://github.com/walaura/node-webshot",
     "yaml-loader": "^0.4.0"


### PR DESCRIPTION

Please update [extract-text-webpack-plugin](https://npmjs.org/package/extract-text-webpack-plugin) to version 3.0.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```d7a75fc```](https://github.com/webpack-contrib/extract-text-webpack-plugin/commit/d7a75fc41880a1909afa948995840643f55c1948) ```chore(release): 3.0.0```
 * [```7ae32d9```](https://github.com/webpack-contrib/extract-text-webpack-plugin/commit/7ae32d9c560ef0a7dd584e3bf5991bacd5753093) ```refactor: Apply webpack-defaults & webpack 3.x support (#540)```
 * [```dd43832```](https://github.com/webpack-contrib/extract-text-webpack-plugin/commit/dd438322f04cd2126a0e18f285f137962afb8ac4) ```fix: add missing `options.ignoreOrder` details in &hellip;```


View the [change log](https://github.com/webpack-contrib/extract-text-webpack-plugin/compare/e81b883df92d120d1fb25ed497af8e24fd04d585...d7a75fc41880a1909afa948995840643f55c1948).