### PR TITLE
Updating react-dom to 16.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "pluralize": "^7.0.0",
     "puppeteer": "^1.0.0",
     "query-string": "^5.0.1",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "request": "^2.83.0",
     "seedrandom": "^2.4.2",
     "spdy": "^3.4.7",


### PR DESCRIPTION

Please update [react-dom](https://npmjs.org/package/react-dom) to version 16.2.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

